### PR TITLE
Close filehandle before renaming

### DIFF
--- a/lib/Hash/Persistent.pm
+++ b/lib/Hash/Persistent.pm
@@ -213,6 +213,7 @@ sub commit {
     print {$tmp} $serialized or die "print failed: $!";
 
     chmod $_self->{mode}, $tmp_fname if defined $_self->{mode};
+    close $tmp;
     rename $tmp_fname => $fname;
 }
 


### PR DESCRIPTION
If the filehandle $tmp is not closed, the rename will fail with 
"permission denied" on Microsoft Windows.
